### PR TITLE
Window dimension issues

### DIFF
--- a/LiveFT.py
+++ b/LiveFT.py
@@ -192,7 +192,7 @@ class LiveFT:
         frame_tensor = torch.tensor(frame, device=self.device)
 
         # Apply an error function window
-        h, w = frame_tensor.shape
+        w, h = frame_tensor.shape
         y = torch.linspace(-1.0, 1.0, h, device=self.device)
         x = torch.linspace(-1.0, 1.0, w, device=self.device)
         x, y = torch.meshgrid(x, y)

--- a/LiveFT.py
+++ b/LiveFT.py
@@ -192,10 +192,10 @@ class LiveFT:
         frame_tensor = torch.tensor(frame, device=self.device)
 
         # Apply an error function window
-        w, h = frame_tensor.shape
+        h, w = frame_tensor.shape
         y = torch.linspace(-1.0, 1.0, h, device=self.device)
         x = torch.linspace(-1.0, 1.0, w, device=self.device)
-        x, y = torch.meshgrid(x, y)
+        x, y = torch.meshgrid(x, y, indexing='xy')
         
         # Create a window using the error function
         taper_width = 0.2  # Adjust the taper width as necessary


### PR DESCRIPTION
LiveFT crashed in the original version with message
```  
File "LiveFT/LiveFT.py", line 208, in _process_image
    frame_tensor *= window
RuntimeError: The size of tensor a (600) must match the size of tensor b (576) at non-singleton dimension 1
```
This is resolved by specifying `indexing='xy'` explicitly in `pytorch.meshgrid`. This change gets rid of a warning at the same time. 

Since it is likely this problem only occurs for certain versions of python modules I include package versions here. 
[environment.txt](https://github.com/user-attachments/files/17834518/environment.txt)



